### PR TITLE
Add mirror attachment option to order form

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,6 +896,7 @@
             <option>Épingle</option>
             <option>Aimant décoratif</option>
             <option>Magnétique textile</option>
+            <option>Miroir</option>
             <option>Décapsuleur magnet</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- add the missing "Miroir" option to the attachment selector when creating an order

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0f0197f388331b5d84247c5784a07