### PR TITLE
Harmoniser les contrastes des thèmes clair et sombre

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,27 @@
       --stroke: rgba(120, 178, 255, 0.18);
       --text: #f3f6ff;
       --muted: #92a2c2;
+      --text-muted: rgba(235, 243, 255, 0.72);
+      --text-subtle: rgba(235, 243, 255, 0.6);
+      --text-soft: rgba(243, 246, 255, 0.68);
+      --text-placeholder: rgba(235, 243, 255, 0.45);
+      --text-faint: rgba(235, 243, 255, 0.4);
+      --ghost-text: rgba(235, 243, 255, 0.85);
+      --border-subtle: rgba(255, 255, 255, 0.18);
+      --control-bg: rgba(255, 255, 255, 0.06);
+      --control-border: rgba(255, 255, 255, 0.08);
+      --ghost-bg: rgba(255, 255, 255, 0.04);
+      --ghost-border: rgba(255, 255, 255, 0.25);
+      --ghost-hover-bg: rgba(142, 250, 219, 0.12);
+      --ghost-hover-border: rgba(142, 250, 219, 0.65);
+      --ghost-hover-text: var(--accent);
+      --ghost-active-bg: rgba(142, 250, 219, 0.18);
+      --ghost-active-border: rgba(142, 250, 219, 0.75);
+      --ghost-active-text: var(--accent);
+      --chip-active-border: rgba(142, 250, 219, 0.55);
+      --note-bg: rgba(13, 24, 42, 0.85);
+      --note-border: rgba(255, 255, 255, 0.12);
+      --note-text: rgba(235, 243, 255, 0.78);
       --accent: #8efadb;
       --accent-2: #94a6ff;
       --accent-soft: rgba(142, 250, 219, 0.22);
@@ -82,6 +103,27 @@
       --stroke: rgba(118, 140, 198, 0.18);
       --text: #1e293b;
       --muted: #5f6c80;
+      --text-muted: #52607a;
+      --text-subtle: #6a7890;
+      --text-soft: #64748b;
+      --text-placeholder: #94a3b8;
+      --text-faint: #9aa5b5;
+      --ghost-text: #1f3d78;
+      --border-subtle: rgba(30, 41, 59, 0.18);
+      --control-bg: rgba(47, 123, 255, 0.12);
+      --control-border: rgba(47, 123, 255, 0.26);
+      --ghost-bg: rgba(47, 123, 255, 0.1);
+      --ghost-border: rgba(47, 123, 255, 0.32);
+      --ghost-hover-bg: rgba(47, 123, 255, 0.16);
+      --ghost-hover-border: rgba(47, 123, 255, 0.5);
+      --ghost-hover-text: var(--accent);
+      --ghost-active-bg: rgba(47, 123, 255, 0.18);
+      --ghost-active-border: rgba(47, 123, 255, 0.55);
+      --ghost-active-text: var(--accent);
+      --chip-active-border: rgba(47, 123, 255, 0.4);
+      --note-bg: rgba(47, 123, 255, 0.1);
+      --note-border: rgba(47, 123, 255, 0.26);
+      --note-text: #1f3d78;
       --accent: #2f7bff;
       --accent-2: #2ac6a8;
       --accent-soft: rgba(47, 123, 255, 0.16);
@@ -299,7 +341,7 @@
     }
     .brand__text span {
       font-size: 0.75rem;
-      color: rgba(235, 243, 255, 0.65);
+      color: var(--text-subtle);
       letter-spacing: 0.4px;
       text-transform: uppercase;
     }
@@ -367,7 +409,7 @@
     }
     .chip-row .chip.active {
       background: var(--accent-soft);
-      border-color: rgba(142, 250, 219, 0.55);
+      border-color: var(--chip-active-border);
       color: var(--text);
       box-shadow: 0 8px 18px rgba(8, 32, 26, 0.4);
     }
@@ -391,7 +433,7 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
     }
     .search input::placeholder {
-      color: rgba(235, 243, 255, 0.45);
+      color: var(--text-placeholder);
     }
     .search .ico {
       position: absolute;
@@ -407,10 +449,10 @@
       gap: 8px;
       padding: 10px 14px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: var(--control-bg);
+      border: 1px solid var(--control-border);
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-      color: rgba(235, 243, 255, 0.76);
+      color: var(--text-muted);
       font-weight: 600;
     }
     .sort-select select {
@@ -492,7 +534,7 @@
     }
     .insight-card span {
       font-size: 0.75rem;
-      color: rgba(243, 246, 255, 0.68);
+      color: var(--text-soft);
       text-transform: uppercase;
       letter-spacing: 1.2px;
     }
@@ -504,7 +546,7 @@
     }
     .insight-card small {
       font-size: 0.8rem;
-      color: rgba(243, 246, 255, 0.68);
+      color: var(--text-subtle);
       line-height: 1.3;
     }
     .insight-card--wide {
@@ -540,18 +582,19 @@
     }
 
     .ghost-small {
-      background: rgba(255, 255, 255, 0.04);
-      border: 1px dashed rgba(255, 255, 255, 0.25);
-      color: rgba(235, 243, 255, 0.85);
+      background: var(--ghost-bg);
+      border: 1px dashed var(--ghost-border);
+      color: var(--ghost-text);
       border-radius: 999px;
       padding: 8px 14px;
       font-weight: 600;
       letter-spacing: 0.2px;
-      transition: border-color 0.2s ease, color 0.2s ease;
+      transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
     }
     .ghost-small:hover {
-      border-color: var(--accent);
-      color: var(--accent);
+      background: var(--ghost-hover-bg);
+      border-color: var(--ghost-hover-border);
+      color: var(--ghost-hover-text);
     }
 
     #list {
@@ -588,7 +631,7 @@
     .handle {
       cursor: grab;
       user-select: none;
-      color: rgba(235, 243, 255, 0.4);
+      color: var(--text-faint);
       font-size: 1.2rem;
     }
     .title {
@@ -613,7 +656,7 @@
       letter-spacing: 0.8px;
       background: rgba(255, 255, 255, 0.06);
       border: 1px solid rgba(255, 255, 255, 0.1);
-      color: rgba(235, 243, 255, 0.85);
+      color: var(--ghost-text);
     }
     .badge[data-s="pause"] {
       background: rgba(246, 201, 69, 0.22);
@@ -627,7 +670,7 @@
     }
     .meta {
       margin-top: 10px;
-      color: rgba(235, 243, 255, 0.72);
+      color: var(--text-muted);
       font-size: 0.82rem;
       display: flex;
       flex-wrap: wrap;
@@ -640,9 +683,9 @@
     .note {
       margin-top: 10px;
       font-size: 0.84rem;
-      color: rgba(235, 243, 255, 0.76);
-      background: rgba(13, 24, 42, 0.85);
-      border: 1px dashed rgba(255, 255, 255, 0.12);
+      color: var(--note-text);
+      background: var(--note-bg);
+      border: 1px dashed var(--note-border);
       padding: 10px 12px;
       border-radius: var(--radius-sm);
     }
@@ -691,11 +734,11 @@
       margin-top: 30px;
       padding: 26px;
       border-radius: var(--radius-lg);
-      border: 1px dashed rgba(255, 255, 255, 0.18);
+      border: 1px dashed var(--border-subtle);
       background:
         linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
       text-align: center;
-      color: rgba(235, 243, 255, 0.72);
+      color: var(--text-muted);
       line-height: 1.5;
       box-shadow: 0 16px 28px rgba(6, 12, 26, 0.35);
     }
@@ -806,14 +849,15 @@
       margin-top: 12px;
     }
     .ghost {
-      background: rgba(255, 255, 255, 0.03);
-      border: 1px dashed rgba(255, 255, 255, 0.24);
-      color: rgba(235, 243, 255, 0.8);
-      transition: border-color 0.2s ease, color 0.2s ease;
+      background: var(--ghost-bg);
+      border: 1px dashed var(--ghost-border);
+      color: var(--ghost-text);
+      transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
     }
     .ghost:hover {
-      border-color: var(--accent);
-      color: var(--accent);
+      background: var(--ghost-hover-bg);
+      border-color: var(--ghost-hover-border);
+      color: var(--ghost-hover-text);
     }
     .theme-grid {
       display: flex;
@@ -821,8 +865,9 @@
       gap: 8px;
     }
     .theme-grid .ghost-small.active {
-      border-color: var(--accent);
-      color: var(--accent);
+      background: var(--ghost-active-bg);
+      border-color: var(--ghost-active-border);
+      color: var(--ghost-active-text);
     }
 
     body.dense .card {


### PR DESCRIPTION
## Summary
- ajoute des variables de couleur dédiées pour les textes secondaires, les contrôles et les boutons fantômes dans chaque thème
- remplace les valeurs RGBA en dur des éléments secondaires par les nouvelles variables et ajuste les états actif/survol
- adapte les notes et les bordures discrètes pour conserver un contraste lisible en clair comme en sombre

## Testing
- playwright script pour vérifier les couleurs des thèmes clair et sombre

------
https://chatgpt.com/codex/tasks/task_e_68d116614f608331a6463e485c1d3bf8