### PR TITLE
Adjust mobile topbar padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,8 +293,8 @@
         z-index: -1;
       }
       .topbar {
-        padding-top: calc(env(safe-area-inset-top, 0) + clamp(18px, 6vw, 28px));
-        padding-bottom: clamp(16px, 5vw, 24px);
+        padding: calc(env(safe-area-inset-top, 0) + clamp(18px, 6vw, 28px)) var(--page-pad)
+          clamp(16px, 5vw, 24px);
       }
       .chip-row {
         margin: 0 calc(-1 * var(--page-pad));


### PR DESCRIPTION
## Summary
- align the mobile topbar horizontal padding with the shared page padding variable so header filters line up with the screen edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d139371a9483319be3528c12dd7a82