### PR TITLE
Add opaque header fallback for browsers without backdrop filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,17 @@
       border-radius: var(--radius-lg);
       box-shadow: var(--header-shadow);
     }
+    @supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+      header {
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        background: var(--surface-strong);
+      }
+      header.page-header::before {
+        display: none;
+        background: var(--surface-strong);
+      }
+    }
     .topbar {
       margin: 0;
       padding: clamp(18px, 3vw, 28px) clamp(18px, 3vw, 28px) clamp(14px, 2.5vw, 22px);


### PR DESCRIPTION
## Summary
- add a `@supports not` rule to disable backdrop filters and use an opaque background for the header
- hide the mobile header overlay pseudo-element when blur is unsupported to avoid transparency bleed-through

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d140343ed4833188429c6b54eb3ec5