### PR TITLE
Fix mobile viewport scrolling behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,8 @@
       margin: 0;
       min-height: 100vh;
       font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      overflow-x: clip;
+      overscroll-behavior-x: contain;
       background:
         radial-gradient(120% 130% at 20% -10%, rgba(148, 166, 255, 0.24) 0%, transparent 55%),
         radial-gradient(120% 160% at 80% 0%, rgba(142, 250, 219, 0.18) 0%, transparent 60%),
@@ -297,7 +299,7 @@
           clamp(16px, 5vw, 24px);
       }
       .chip-row {
-        margin: 0 calc(-1 * var(--page-pad));
+        margin: 0;
         padding: 0 var(--page-pad) 4px;
       }
       .chip-row .chip {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on the body to stop mobile viewport drifting
- remove the negative mobile chip row margin so the header stays within the screen width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1482bc71c83319b6ce7b73a14ce78