### PR TITLE
Align mobile chip row padding with topbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
       }
       .chip-row {
         margin: 0;
-        padding: 0 var(--page-pad) 4px;
+        padding-bottom: 4px;
       }
       .chip-row .chip {
         padding: 10px 18px;


### PR DESCRIPTION
## Summary
- update the mobile `.chip-row` styles to remove horizontal padding while keeping the bottom spacing

## Testing
- browser_container mobile viewport check

------
https://chatgpt.com/codex/tasks/task_e_68d14b57c01083319000e0ae94389b08