### PR TITLE
Adjust status badges and replace card action text with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,11 +75,11 @@
       --btn-bg: rgba(10, 20, 36, 0.82);
       --btn-border: rgba(255, 255, 255, 0.08);
       --btn-text: #f3f6ff;
-      --btn-pause-bg: rgba(246, 201, 69, 0.24);
-      --btn-pause-border: rgba(246, 201, 69, 0.45);
-      --btn-pause-text: #1f1908;
-      --btn-done-bg: rgba(79, 229, 173, 0.25);
-      --btn-done-border: rgba(79, 229, 173, 0.45);
+      --btn-pause-bg: rgba(255, 183, 102, 0.24);
+      --btn-pause-border: rgba(255, 183, 102, 0.48);
+      --btn-pause-text: #2f1a07;
+      --btn-done-bg: rgba(0, 214, 153, 0.26);
+      --btn-done-border: rgba(0, 214, 153, 0.48);
       --btn-done-text: #012c1b;
       --btn-del-bg: rgba(255, 87, 116, 0.28);
       --btn-del-border: rgba(255, 87, 116, 0.45);
@@ -117,15 +117,15 @@
       --insight-card-highlight: radial-gradient(circle at top right, rgba(255, 255, 255, 0.12), transparent 60%);
       --card-bg: linear-gradient(155deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 80%), var(--surface);
       --card-border: rgba(255, 255, 255, 0.08);
-      --badge-bg: rgba(255, 255, 255, 0.06);
-      --badge-border: rgba(255, 255, 255, 0.1);
-      --badge-text: var(--ghost-text);
-      --badge-pause-bg: rgba(246, 201, 69, 0.22);
-      --badge-pause-border: rgba(246, 201, 69, 0.55);
-      --badge-pause-text: #1e1b09;
-      --badge-done-bg: rgba(79, 229, 173, 0.25);
-      --badge-done-border: rgba(79, 229, 173, 0.55);
-      --badge-done-text: #022b1a;
+      --badge-bg: rgba(122, 162, 255, 0.22);
+      --badge-border: rgba(122, 162, 255, 0.5);
+      --badge-text: #e1eaff;
+      --badge-pause-bg: rgba(255, 183, 102, 0.26);
+      --badge-pause-border: rgba(255, 183, 102, 0.58);
+      --badge-pause-text: #2e1a08;
+      --badge-done-bg: rgba(0, 214, 153, 0.3);
+      --badge-done-border: rgba(0, 214, 153, 0.62);
+      --badge-done-text: #032a19;
       --insight-progress-bg: rgba(255, 255, 255, 0.08);
     }
     [data-theme="light"] {
@@ -168,11 +168,11 @@
       --btn-bg: #2f7bff;
       --btn-border: #2260d1;
       --btn-text: #ffffff;
-      --btn-pause-bg: #f6c945;
-      --btn-pause-border: #c58f06;
-      --btn-pause-text: #3f2d00;
-      --btn-done-bg: #2eaf70;
-      --btn-done-border: #1f7a4d;
+      --btn-pause-bg: #f8b06a;
+      --btn-pause-border: #d27a2a;
+      --btn-pause-text: #4a2608;
+      --btn-done-bg: #24c48b;
+      --btn-done-border: #1a8d62;
       --btn-done-text: #ffffff;
       --btn-del-bg: #d64562;
       --btn-del-border: #a62f47;
@@ -210,15 +210,15 @@
       --insight-card-highlight: radial-gradient(circle at top right, rgba(47, 123, 255, 0.22), transparent 60%);
       --card-bg: linear-gradient(155deg, rgba(47, 123, 255, 0.12) 0%, rgba(42, 198, 168, 0.08) 80%), var(--surface);
       --card-border: rgba(30, 41, 59, 0.12);
-      --badge-bg: rgba(47, 123, 255, 0.12);
-      --badge-border: rgba(47, 123, 255, 0.26);
+      --badge-bg: rgba(119, 150, 255, 0.18);
+      --badge-border: rgba(119, 150, 255, 0.36);
       --badge-text: #1f3d78;
-      --badge-pause-bg: rgba(246, 201, 69, 0.26);
-      --badge-pause-border: rgba(197, 143, 6, 0.55);
-      --badge-pause-text: #3f2d00;
-      --badge-done-bg: rgba(46, 175, 112, 0.22);
-      --badge-done-border: rgba(31, 122, 77, 0.45);
-      --badge-done-text: #0d4128;
+      --badge-pause-bg: rgba(248, 176, 106, 0.3);
+      --badge-pause-border: rgba(210, 122, 42, 0.58);
+      --badge-pause-text: #542b07;
+      --badge-done-bg: rgba(36, 196, 139, 0.28);
+      --badge-done-border: rgba(26, 141, 98, 0.55);
+      --badge-done-text: #0b3a27;
       --insight-progress-bg: rgba(30, 41, 59, 0.12);
     }
 
@@ -1163,24 +1163,34 @@
     }
     .actions {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(var(--touch), 1fr));
       gap: 10px;
       margin-top: 14px;
     }
     .btn {
       min-height: var(--touch);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      padding: 0;
       border-radius: var(--radius-sm);
       border: 1px solid var(--btn-border);
       background: var(--btn-bg);
       color: var(--btn-text);
-      font-weight: 700;
-      letter-spacing: 0.2px;
+      line-height: 1;
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
       transition: transform 0.18s ease, box-shadow 0.18s ease;
     }
     .btn:hover {
       transform: translateY(-1px);
       box-shadow: 0 12px 22px rgba(5, 12, 26, 0.35);
+    }
+    .btn svg {
+      width: 22px;
+      height: 22px;
+      display: block;
+      pointer-events: none;
     }
     .btn[data-a="pause"] {
       background: var(--btn-pause-bg);
@@ -1882,6 +1892,18 @@
     const URGENT_DELAY_MS = 90 * 60 * 1000;
     const RECENT_DONE_MS = 24 * 60 * 60 * 1000;
     const HIGH_VOLUME_QTY = 200;
+    const ICONS = {
+      edit: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>',
+      pause: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16" rx="1"></rect><rect x="14" y="4" width="4" height="16" rx="1"></rect></svg>',
+      play: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><polygon points="7 4 19 12 7 20 7 4"></polygon></svg>',
+      check: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 10 16 4 11"></polyline></svg>',
+      refresh: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 4 20 9 15 9"></polyline><polyline points="4 20 4 15 9 15"></polyline><path d="M5.6 9A7 7 0 0 1 19 9"></path><path d="M19 15a7 7 0 0 1-13.4 1"></path></svg>',
+      trash: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>',
+    };
+
+    Object.keys(ICONS).forEach((key) => {
+      ICONS[key] = ICONS[key].trim();
+    });
 
     function isValidTheme(value) {
       return value === "light" || value === "dark";
@@ -3316,6 +3338,10 @@
           const liveSec = getEffectiveSeconds(i, nowTs);
           const longAwait = isWait && nowTs - (i.startTime || nowTs) > 3600 * 1000;
           const cls = longAwait ? "card awaiting-long" : "card";
+          const pauseLabel = i.status === "pause" ? "Reprendre" : "Pause";
+          const pauseIcon = i.status === "pause" ? ICONS.play : ICONS.pause;
+          const doneLabel = i.status === "done" ? "Reprendre" : "Terminer";
+          const doneIcon = i.status === "done" ? ICONS.refresh : ICONS.check;
           return `
           <div class="${cls}" data-id="${i.id}">
             <div class="row">
@@ -3344,10 +3370,10 @@
             </div>
             ${i.note ? `<div class="note">📝 ${escapeHtml(i.note)}</div>` : ""}
             <div class="actions">
-              <button class="btn" data-a="edit">Éditer</button>
-              <button class="btn" data-a="pause">${i.status === "pause" ? "Reprendre" : "Pause"}</button>
-              <button class="btn" data-a="done">${i.status === "done" ? "Reprendre" : "Terminer"}</button>
-              <button class="btn" data-a="del">Supprimer</button>
+              <button class="btn" type="button" data-a="edit" title="Éditer" aria-label="Éditer">${ICONS.edit}<span class="sr-only">Éditer</span></button>
+              <button class="btn" type="button" data-a="pause" title="${pauseLabel}" aria-label="${pauseLabel}">${pauseIcon}<span class="sr-only">${pauseLabel}</span></button>
+              <button class="btn" type="button" data-a="done" title="${doneLabel}" aria-label="${doneLabel}">${doneIcon}<span class="sr-only">${doneLabel}</span></button>
+              <button class="btn" type="button" data-a="del" title="Supprimer" aria-label="Supprimer">${ICONS.trash}<span class="sr-only">Supprimer</span></button>
             </div>
           </div>
         `;


### PR DESCRIPTION
## Summary
- update status badge and button color tokens to match the requested palette for wait, pause and done states in both themes
- restyle card action buttons as icon-only controls and inject inline SVGs with accessible labels

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d410e12a948331bc8ff75b3c451ccf