### PR TITLE
feat: harmonize dashboard palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <!-- PWA -->
   <link rel="manifest" href="./manifest.webmanifest" />
-  <meta name="theme-color" content="#8efadb" />
+  <meta name="theme-color" content="#5ab7a4" />
 
   <!-- Fonts & Favicon -->
   <link
@@ -37,189 +37,189 @@
     }
     [data-theme="dark"] {
       color-scheme: dark;
-      --bg: #030611;
-      --bg-alt: #050a16;
-      --surface: rgba(11, 19, 35, 0.9);
-      --surface-strong: #0b1324;
-      --surface-soft: rgba(14, 24, 42, 0.78);
-      --stroke: rgba(120, 178, 255, 0.18);
-      --text: #f3f6ff;
-      --muted: #92a2c2;
-      --text-muted: rgba(235, 243, 255, 0.72);
-      --text-subtle: rgba(235, 243, 255, 0.6);
-      --text-soft: rgba(243, 246, 255, 0.68);
-      --text-placeholder: rgba(235, 243, 255, 0.45);
-      --text-faint: rgba(235, 243, 255, 0.4);
-      --ghost-text: rgba(235, 243, 255, 0.85);
-      --border-subtle: rgba(255, 255, 255, 0.18);
-      --control-bg: rgba(255, 255, 255, 0.06);
+      --bg: #050910;
+      --bg-alt: #081120;
+      --surface: rgba(13, 21, 34, 0.92);
+      --surface-strong: #0f1a2b;
+      --surface-soft: rgba(16, 26, 42, 0.78);
+      --stroke: rgba(104, 150, 206, 0.18);
+      --text: #f4f6fb;
+      --muted: #9aa7c2;
+      --text-muted: rgba(231, 236, 247, 0.75);
+      --text-subtle: rgba(231, 236, 247, 0.62);
+      --text-soft: rgba(244, 246, 251, 0.68);
+      --text-placeholder: rgba(220, 229, 242, 0.45);
+      --text-faint: rgba(220, 229, 242, 0.38);
+      --ghost-text: rgba(226, 236, 248, 0.85);
+      --border-subtle: rgba(255, 255, 255, 0.16);
+      --control-bg: rgba(255, 255, 255, 0.05);
       --control-border: rgba(255, 255, 255, 0.08);
       --ghost-bg: rgba(255, 255, 255, 0.04);
-      --ghost-border: rgba(255, 255, 255, 0.25);
-      --ghost-hover-bg: rgba(142, 250, 219, 0.12);
-      --ghost-hover-border: rgba(142, 250, 219, 0.65);
+      --ghost-border: rgba(255, 255, 255, 0.22);
+      --ghost-hover-bg: rgba(90, 183, 164, 0.14);
+      --ghost-hover-border: rgba(90, 183, 164, 0.58);
       --ghost-hover-text: var(--accent);
-      --ghost-active-bg: rgba(142, 250, 219, 0.18);
-      --ghost-active-border: rgba(142, 250, 219, 0.75);
+      --ghost-active-bg: rgba(90, 183, 164, 0.2);
+      --ghost-active-border: rgba(90, 183, 164, 0.68);
       --ghost-active-text: var(--accent);
-      --chip-active-border: rgba(142, 250, 219, 0.55);
-      --note-bg: rgba(13, 24, 42, 0.85);
-      --note-border: rgba(255, 255, 255, 0.12);
-      --note-text: rgba(235, 243, 255, 0.78);
-      --accent: #8efadb;
-      --accent-2: #94a6ff;
-      --accent-soft: rgba(142, 250, 219, 0.22);
-      --warn: #f6c945;
-      --danger: #ff5774;
-      --ok: #4fe5ad;
+      --chip-active-border: rgba(90, 183, 164, 0.5);
+      --note-bg: rgba(14, 26, 44, 0.85);
+      --note-border: rgba(255, 255, 255, 0.1);
+      --note-text: rgba(226, 234, 247, 0.78);
+      --accent: #5ab7a4;
+      --accent-2: #7387d7;
+      --accent-soft: rgba(90, 183, 164, 0.2);
+      --warn: #f2b36a;
+      --danger: #f07a8d;
+      --ok: #68d4ac;
       --btn-bg: rgba(10, 20, 36, 0.82);
       --btn-border: rgba(255, 255, 255, 0.08);
-      --btn-text: #f3f6ff;
-      --btn-pause-bg: rgba(255, 183, 102, 0.24);
-      --btn-pause-border: rgba(255, 183, 102, 0.48);
-      --btn-pause-text: #2f1a07;
-      --btn-done-bg: rgba(0, 214, 153, 0.26);
-      --btn-done-border: rgba(0, 214, 153, 0.48);
-      --btn-done-text: #012c1b;
-      --btn-del-bg: rgba(255, 87, 116, 0.28);
-      --btn-del-border: rgba(255, 87, 116, 0.45);
+      --btn-text: #f4f6fb;
+      --btn-pause-bg: rgba(242, 179, 106, 0.24);
+      --btn-pause-border: rgba(242, 179, 106, 0.5);
+      --btn-pause-text: #2f1f0f;
+      --btn-done-bg: rgba(104, 212, 172, 0.24);
+      --btn-done-border: rgba(104, 212, 172, 0.48);
+      --btn-done-text: #062822;
+      --btn-del-bg: rgba(240, 122, 141, 0.26);
+      --btn-del-border: rgba(240, 122, 141, 0.45);
       --btn-del-text: #ffeef2;
-      --input-bg: rgba(7, 14, 26, 0.85);
-      --input-text: #f3f6ff;
+      --input-bg: rgba(9, 16, 28, 0.88);
+      --input-text: #f4f6fb;
       --input-border: rgba(255, 255, 255, 0.12);
-      --input-focus-border: rgba(111, 255, 233, 0.45);
-      --input-focus-ring: rgba(111, 255, 233, 0.15);
+      --input-focus-border: rgba(90, 183, 164, 0.45);
+      --input-focus-ring: rgba(90, 183, 164, 0.14);
       --brand-gradient: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
       --shadow-lg: 0 24px 46px rgba(4, 8, 20, 0.55);
       --shadow-md: 0 14px 32px rgba(5, 10, 25, 0.45);
-      --header-bg: linear-gradient(185deg, rgba(7, 12, 24, 0.94) 0%, rgba(7, 12, 24, 0.66) 100%);
+      --header-bg: linear-gradient(185deg, rgba(7, 12, 24, 0.94) 0%, rgba(7, 12, 24, 0.68) 100%);
       --header-border: rgba(255, 255, 255, 0.08);
       --header-shadow: 0 24px 46px rgba(4, 8, 20, 0.55);
       --header-sticky-shadow: 0 18px 32px rgba(4, 8, 20, 0.55);
-      --header-overlay: linear-gradient(185deg, rgba(7, 12, 24, 0.96), rgba(7, 12, 24, 0.7));
+      --header-overlay: linear-gradient(185deg, rgba(7, 12, 24, 0.96), rgba(7, 12, 24, 0.72));
       --header-icon-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0.02) 100%),
         var(--surface);
       --header-icon-border: rgba(255, 255, 255, 0.12);
       --header-icon-shadow: 0 10px 26px rgba(6, 12, 24, 0.45);
-      --chip-bg: rgba(255, 255, 255, 0.06);
-      --chip-border: rgba(255, 255, 255, 0.08);
-      --chip-active-shadow: 0 8px 18px rgba(8, 32, 26, 0.4);
-      --field-bg: rgba(15, 24, 38, 0.9);
-      --field-border: rgba(255, 255, 255, 0.08);
+      --chip-bg: rgba(255, 255, 255, 0.05);
+      --chip-border: rgba(255, 255, 255, 0.12);
+      --chip-active-shadow: 0 8px 18px rgba(6, 27, 24, 0.4);
+      --field-bg: rgba(16, 26, 42, 0.9);
+      --field-border: rgba(255, 255, 255, 0.1);
       --field-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
       --insight-bg: linear-gradient(165deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)),
         var(--surface);
       --insight-border: rgba(255, 255, 255, 0.12);
-      --insight-card-bg: linear-gradient(165deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0) 75%),
+      --insight-card-bg: linear-gradient(165deg, rgba(115, 135, 215, 0.16) 0%, rgba(90, 183, 164, 0.08) 75%),
         var(--surface-soft);
       --insight-card-border: rgba(255, 255, 255, 0.08);
       --insight-card-shadow: 0 18px 32px rgba(4, 10, 24, 0.35);
-      --insight-card-highlight: radial-gradient(circle at top right, rgba(255, 255, 255, 0.12), transparent 60%);
+      --insight-card-highlight: radial-gradient(circle at top right, rgba(115, 135, 215, 0.16), transparent 60%);
       --card-bg: linear-gradient(155deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 80%), var(--surface);
       --card-border: rgba(255, 255, 255, 0.08);
-      --badge-bg: rgba(122, 162, 255, 0.22);
-      --badge-border: rgba(122, 162, 255, 0.5);
-      --badge-text: #e1eaff;
-      --badge-pause-bg: rgba(255, 183, 102, 0.26);
-      --badge-pause-border: rgba(255, 183, 102, 0.58);
-      --badge-pause-text: #2e1a08;
-      --badge-done-bg: rgba(0, 214, 153, 0.3);
-      --badge-done-border: rgba(0, 214, 153, 0.62);
-      --badge-done-text: #032a19;
+      --badge-bg: rgba(115, 135, 215, 0.22);
+      --badge-border: rgba(115, 135, 215, 0.5);
+      --badge-text: #e2e6fb;
+      --badge-pause-bg: rgba(242, 179, 106, 0.26);
+      --badge-pause-border: rgba(242, 179, 106, 0.58);
+      --badge-pause-text: #2f1f0f;
+      --badge-done-bg: rgba(90, 183, 164, 0.28);
+      --badge-done-border: rgba(90, 183, 164, 0.6);
+      --badge-done-text: #062822;
       --insight-progress-bg: rgba(255, 255, 255, 0.08);
     }
     [data-theme="light"] {
       color-scheme: light;
-      --bg: #f4f7fb;
+      --bg: #f5f7fa;
       --bg-alt: #ffffff;
-      --surface: rgba(255, 255, 255, 0.92);
+      --surface: rgba(255, 255, 255, 0.94);
       --surface-strong: #ffffff;
-      --surface-soft: rgba(241, 245, 255, 0.78);
-      --stroke: rgba(118, 140, 198, 0.18);
-      --text: #1e293b;
-      --muted: #5f6c80;
-      --text-muted: #52607a;
-      --text-subtle: #6a7890;
-      --text-soft: #64748b;
-      --text-placeholder: #94a3b8;
+      --surface-soft: rgba(237, 242, 250, 0.78);
+      --stroke: rgba(96, 120, 168, 0.16);
+      --text: #1f2937;
+      --muted: #5c687a;
+      --text-muted: #556173;
+      --text-subtle: #6a7688;
+      --text-soft: #5f6c80;
+      --text-placeholder: #8b97aa;
       --text-faint: #9aa5b5;
-      --ghost-text: #1f3d78;
-      --border-subtle: rgba(30, 41, 59, 0.18);
-      --control-bg: rgba(47, 123, 255, 0.12);
-      --control-border: rgba(47, 123, 255, 0.26);
-      --ghost-bg: rgba(47, 123, 255, 0.1);
-      --ghost-border: rgba(47, 123, 255, 0.32);
-      --ghost-hover-bg: rgba(47, 123, 255, 0.16);
-      --ghost-hover-border: rgba(47, 123, 255, 0.5);
+      --ghost-text: #274b53;
+      --border-subtle: rgba(31, 41, 55, 0.14);
+      --control-bg: rgba(63, 136, 121, 0.12);
+      --control-border: rgba(63, 136, 121, 0.24);
+      --ghost-bg: rgba(63, 136, 121, 0.1);
+      --ghost-border: rgba(63, 136, 121, 0.28);
+      --ghost-hover-bg: rgba(63, 136, 121, 0.18);
+      --ghost-hover-border: rgba(63, 136, 121, 0.45);
       --ghost-hover-text: var(--accent);
-      --ghost-active-bg: rgba(47, 123, 255, 0.18);
-      --ghost-active-border: rgba(47, 123, 255, 0.55);
+      --ghost-active-bg: rgba(63, 136, 121, 0.2);
+      --ghost-active-border: rgba(63, 136, 121, 0.52);
       --ghost-active-text: var(--accent);
-      --chip-active-border: rgba(47, 123, 255, 0.4);
-      --note-bg: rgba(47, 123, 255, 0.1);
-      --note-border: rgba(47, 123, 255, 0.26);
-      --note-text: #1f3d78;
-      --accent: #2f7bff;
-      --accent-2: #2ac6a8;
-      --accent-soft: rgba(47, 123, 255, 0.16);
-      --warn: #d9941a;
-      --danger: #d64562;
-      --ok: #2eaf70;
-      --btn-bg: #2f7bff;
-      --btn-border: #2260d1;
+      --chip-active-border: rgba(63, 136, 121, 0.36);
+      --note-bg: rgba(63, 136, 121, 0.12);
+      --note-border: rgba(63, 136, 121, 0.32);
+      --note-text: #2d4f47;
+      --accent: #3f8879;
+      --accent-2: #5d6ed6;
+      --accent-soft: rgba(63, 136, 121, 0.16);
+      --warn: #d7964b;
+      --danger: #ce546d;
+      --ok: #2e9e78;
+      --btn-bg: #3f8879;
+      --btn-border: #2f6c5f;
       --btn-text: #ffffff;
-      --btn-pause-bg: #f8b06a;
-      --btn-pause-border: #d27a2a;
-      --btn-pause-text: #4a2608;
-      --btn-done-bg: #24c48b;
-      --btn-done-border: #1a8d62;
+      --btn-pause-bg: #f0b47a;
+      --btn-pause-border: #ca7f38;
+      --btn-pause-text: #432a0e;
+      --btn-done-bg: #45b892;
+      --btn-done-border: #31886a;
       --btn-done-text: #ffffff;
-      --btn-del-bg: #d64562;
-      --btn-del-border: #a62f47;
+      --btn-del-bg: #ce546d;
+      --btn-del-border: #a53d54;
       --btn-del-text: #ffffff;
       --input-bg: #ffffff;
-      --input-text: #1e293b;
-      --input-border: rgba(28, 51, 101, 0.2);
-      --input-focus-border: rgba(47, 123, 255, 0.45);
-      --input-focus-ring: rgba(47, 123, 255, 0.15);
+      --input-text: #1f2937;
+      --input-border: rgba(28, 51, 101, 0.18);
+      --input-focus-border: rgba(63, 136, 121, 0.45);
+      --input-focus-ring: rgba(63, 136, 121, 0.18);
       --brand-gradient: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
-      --shadow-lg: 0 24px 40px rgba(15, 35, 95, 0.12);
-      --shadow-md: 0 14px 28px rgba(18, 36, 90, 0.1);
-      --header-bg: linear-gradient(185deg, rgba(255, 255, 255, 0.95) 0%, rgba(232, 239, 255, 0.88) 100%);
-      --header-border: rgba(30, 41, 59, 0.12);
-      --header-shadow: 0 24px 36px rgba(15, 35, 95, 0.15);
-      --header-sticky-shadow: 0 18px 24px rgba(15, 35, 95, 0.14);
-      --header-overlay: linear-gradient(185deg, rgba(255, 255, 255, 0.96), rgba(232, 239, 255, 0.78));
-      --header-icon-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.96) 0%, rgba(232, 239, 255, 0.8) 100%),
+      --shadow-lg: 0 24px 40px rgba(28, 45, 82, 0.12);
+      --shadow-md: 0 14px 28px rgba(24, 42, 78, 0.1);
+      --header-bg: linear-gradient(185deg, rgba(255, 255, 255, 0.96) 0%, rgba(239, 244, 255, 0.88) 100%);
+      --header-border: rgba(31, 41, 55, 0.12);
+      --header-shadow: 0 24px 36px rgba(28, 45, 82, 0.14);
+      --header-sticky-shadow: 0 18px 24px rgba(28, 45, 82, 0.12);
+      --header-overlay: linear-gradient(185deg, rgba(255, 255, 255, 0.96), rgba(239, 244, 255, 0.78));
+      --header-icon-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.96) 0%, rgba(239, 244, 255, 0.82) 100%),
         var(--surface);
-      --header-icon-border: rgba(30, 41, 59, 0.16);
-      --header-icon-shadow: 0 12px 24px rgba(15, 35, 95, 0.15);
-      --chip-bg: rgba(47, 123, 255, 0.12);
-      --chip-border: rgba(47, 123, 255, 0.26);
-      --chip-active-shadow: 0 8px 18px rgba(47, 123, 255, 0.3);
+      --header-icon-border: rgba(31, 41, 55, 0.16);
+      --header-icon-shadow: 0 12px 24px rgba(28, 45, 82, 0.15);
+      --chip-bg: rgba(63, 136, 121, 0.12);
+      --chip-border: rgba(63, 136, 121, 0.26);
+      --chip-active-shadow: 0 8px 18px rgba(63, 136, 121, 0.28);
       --field-bg: #ffffff;
-      --field-border: rgba(28, 51, 101, 0.2);
+      --field-border: rgba(28, 51, 101, 0.18);
       --field-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-      --insight-bg: linear-gradient(165deg, rgba(47, 123, 255, 0.14), rgba(42, 198, 168, 0.06)),
+      --insight-bg: linear-gradient(165deg, rgba(63, 136, 121, 0.14), rgba(93, 110, 214, 0.08)),
         var(--surface);
-      --insight-border: rgba(30, 41, 59, 0.12);
-      --insight-card-bg: linear-gradient(165deg, rgba(47, 123, 255, 0.16) 0%, rgba(42, 198, 168, 0.08) 75%),
+      --insight-border: rgba(31, 41, 55, 0.12);
+      --insight-card-bg: linear-gradient(165deg, rgba(93, 110, 214, 0.14) 0%, rgba(63, 136, 121, 0.08) 75%),
         var(--surface-soft);
-      --insight-card-border: rgba(47, 123, 255, 0.2);
-      --insight-card-shadow: 0 18px 32px rgba(47, 123, 255, 0.18);
-      --insight-card-highlight: radial-gradient(circle at top right, rgba(47, 123, 255, 0.22), transparent 60%);
-      --card-bg: linear-gradient(155deg, rgba(47, 123, 255, 0.12) 0%, rgba(42, 198, 168, 0.08) 80%), var(--surface);
-      --card-border: rgba(30, 41, 59, 0.12);
-      --badge-bg: rgba(119, 150, 255, 0.18);
-      --badge-border: rgba(119, 150, 255, 0.36);
-      --badge-text: #1f3d78;
-      --badge-pause-bg: rgba(248, 176, 106, 0.3);
-      --badge-pause-border: rgba(210, 122, 42, 0.58);
-      --badge-pause-text: #542b07;
-      --badge-done-bg: rgba(36, 196, 139, 0.28);
-      --badge-done-border: rgba(26, 141, 98, 0.55);
-      --badge-done-text: #0b3a27;
-      --insight-progress-bg: rgba(30, 41, 59, 0.12);
+      --insight-card-border: rgba(63, 136, 121, 0.2);
+      --insight-card-shadow: 0 18px 32px rgba(63, 136, 121, 0.18);
+      --insight-card-highlight: radial-gradient(circle at top right, rgba(93, 110, 214, 0.2), transparent 60%);
+      --card-bg: linear-gradient(155deg, rgba(63, 136, 121, 0.12) 0%, rgba(93, 110, 214, 0.08) 80%), var(--surface);
+      --card-border: rgba(31, 41, 55, 0.12);
+      --badge-bg: rgba(101, 138, 214, 0.18);
+      --badge-border: rgba(101, 138, 214, 0.34);
+      --badge-text: #29406d;
+      --badge-pause-bg: rgba(240, 180, 122, 0.28);
+      --badge-pause-border: rgba(202, 127, 56, 0.54);
+      --badge-pause-text: #513312;
+      --badge-done-bg: rgba(63, 136, 121, 0.24);
+      --badge-done-border: rgba(63, 136, 121, 0.5);
+      --badge-done-text: #0f372d;
+      --insight-progress-bg: rgba(31, 41, 55, 0.12);
     }
 
     * {
@@ -232,8 +232,8 @@
       overflow-x: clip;
       overscroll-behavior-x: contain;
       background:
-        radial-gradient(120% 130% at 20% -10%, rgba(148, 166, 255, 0.24) 0%, transparent 55%),
-        radial-gradient(120% 160% at 80% 0%, rgba(142, 250, 219, 0.18) 0%, transparent 60%),
+        radial-gradient(120% 130% at 20% -10%, rgba(115, 135, 215, 0.22) 0%, transparent 55%),
+        radial-gradient(120% 160% at 80% 0%, rgba(90, 183, 164, 0.18) 0%, transparent 60%),
         linear-gradient(180deg, var(--bg) 0%, var(--bg-alt) 100%);
       color: var(--text);
       padding: var(--page-pad);
@@ -384,7 +384,7 @@
       height: clamp(160px, 28vw, 220px);
       background: radial-gradient(
         120% 140% at 50% 50%,
-        rgba(148, 166, 255, 0.32),
+        rgba(115, 135, 215, 0.32),
         transparent 70%
       );
       opacity: 0.35;
@@ -439,7 +439,7 @@
       height: 160px;
       background: radial-gradient(
         120% 140% at 0% 50%,
-        rgba(142, 250, 219, 0.32),
+        rgba(90, 183, 164, 0.32),
         transparent 68%
       );
       opacity: 0.7;
@@ -789,7 +789,7 @@
       width: 0;
       background: var(--brand-gradient);
       border-radius: inherit;
-      box-shadow: 0 8px 18px rgba(142, 250, 219, 0.35);
+      box-shadow: 0 8px 18px rgba(90, 183, 164, 0.32);
       transition: width 0.25s ease;
     }
     .command-menu__progress-value {
@@ -1016,7 +1016,7 @@
       font-size: 1.7rem;
       font-weight: 700;
       color: var(--accent);
-      text-shadow: 0 6px 18px rgba(142, 250, 219, 0.35);
+      text-shadow: 0 6px 18px rgba(90, 183, 164, 0.32);
     }
     .insight-card small {
       font-size: 0.8rem;
@@ -1045,7 +1045,7 @@
       width: 0;
       background: var(--brand-gradient);
       border-radius: inherit;
-      box-shadow: 0 4px 12px rgba(142, 250, 219, 0.35);
+      box-shadow: 0 4px 12px rgba(90, 183, 164, 0.28);
       transition: width 0.25s ease;
     }
     .insights__actions {
@@ -1208,8 +1208,8 @@
       border-color: var(--btn-del-border);
     }
     .awaiting-long {
-      border-color: rgba(148, 166, 255, 0.55);
-      box-shadow: 0 0 0 1px rgba(148, 166, 255, 0.45) inset, var(--shadow-md);
+      border-color: rgba(115, 135, 215, 0.5);
+      box-shadow: 0 0 0 1px rgba(115, 135, 215, 0.42) inset, var(--shadow-md);
     }
 
     .empty-state {
@@ -4147,7 +4147,7 @@
         g: 0.18,
         s: Math.random() * 3 + 2,
         a: 1,
-        col: Math.random() > 0.5 ? "#fff" : Math.random() > 0.5 ? "#ffd166" : "#8efadb",
+        col: Math.random() > 0.5 ? "#fff" : Math.random() > 0.5 ? "#ffd166" : "#5ab7a4",
       }));
       let t = 0;
       function step() {


### PR DESCRIPTION
## Summary
- retune the dark theme variables with a calmer teal and indigo palette for a more professional feel
- align the light theme colors, gradients, and controls with the updated brand accents
- refresh supporting visuals like glows, progress effects, and confetti to reuse the mature colourway

## Testing
- not run (static asset changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d4169d4218833191c922368e7480d0