### PR TITLE
Nettoie le menu et clarifie les vues intelligentes

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,10 +315,11 @@
         min-height: 46px;
         font-size: 1rem;
       }
-      .sort-select {
+      .smart-badge {
+        width: 100%;
         justify-content: space-between;
-        min-height: 46px;
-        font-size: 0.95rem;
+        align-items: center;
+        font-size: 0.9rem;
       }
       .page-main {
         border-radius: 0;
@@ -609,29 +610,44 @@
       font-size: 1.05rem;
       opacity: 0.7;
     }
-    .sort-select {
-      display: flex;
+    .smart-badge {
+      display: inline-flex;
       align-items: center;
       gap: 8px;
+      flex-wrap: wrap;
       padding: 10px 14px;
       border-radius: 999px;
-      background: var(--control-bg);
-      border: 1px solid var(--control-border);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-      color: var(--text-muted);
+      background: var(--ghost-bg);
+      border: 1px solid var(--ghost-border);
+      color: var(--ghost-text);
+      font-size: 0.85rem;
       font-weight: 600;
     }
-    .sort-select select {
+    .smart-badge strong {
+      color: var(--text);
+      font-size: 0.9rem;
+      font-weight: 700;
+    }
+    .smart-badge button {
       background: transparent;
       border: none;
-      color: inherit;
+      color: var(--accent);
       font-weight: 600;
-      font-size: 0.95rem;
-      appearance: none;
-      padding-right: 12px;
+      font-size: 0.8rem;
+      cursor: pointer;
+      padding: 0;
     }
-    .sort-select select:focus {
-      outline: none;
+    .smart-badge button:hover,
+    .smart-badge button:focus-visible {
+      text-decoration: underline;
+    }
+    .smart-badge button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+      border-radius: 6px;
+    }
+    .smart-badge[hidden] {
+      display: none;
     }
 
     .menu-overlay {
@@ -1499,16 +1515,13 @@
           />
           <span class="ico">🔎</span>
         </div>
-        <label class="sort-select" for="sortBy">
-          <span>⇅</span>
-          <select id="sortBy" title="Trier les commandes">
-            <option value="recent">Récent → ancien</option>
-            <option value="oldest">Ancien → récent</option>
-            <option value="qty">Quantité</option>
-            <option value="client">Client A → Z</option>
-            <option value="status">Statut</option>
-          </select>
-        </label>
+        <div class="smart-badge" id="smartFilterBadge" hidden role="status" aria-live="polite">
+          <span>Vue intelligente&nbsp;:</span>
+          <strong id="smartFilterBadgeLabel"></strong>
+          <button type="button" data-smart-reset title="Réinitialiser la vue intelligente">
+            Réinitialiser
+          </button>
+        </div>
       </div>
     </div>
     </header>
@@ -3031,8 +3044,6 @@
       }
       sortBy = next;
       localStorage.setItem("vmach_sort", sortBy);
-      const select = $("#sortBy");
-      if (select) select.value = sortBy;
       updateSortMenuUI();
       if (!skipRender) render();
     }
@@ -3072,12 +3083,6 @@
       search = e.target.value.trim().toLowerCase();
       render();
     };
-    $("#sortBy").value = sortBy;
-    $("#sortBy").onchange = (e) => {
-      setSort(e.target.value);
-      vibrate();
-    };
-
     /* ====== Add/Edit Sheet ====== */
     const sheet = $("#sheet");
     const orderForm = $("#orderForm");
@@ -3279,9 +3284,11 @@
       const labelEl = document.getElementById("smartFilterBadgeLabel");
       if (smartFilter === "default") {
         badge.hidden = true;
+        badge.setAttribute("aria-hidden", "true");
         return;
       }
       badge.hidden = false;
+      badge.setAttribute("aria-hidden", "false");
       if (labelEl) labelEl.textContent = getSmartFilterConfig(smartFilter).label;
     }
 


### PR DESCRIPTION
## Summary
- retire l’ancien sélecteur de tri du header et le remplace par un badge de vue intelligente réinitialisable
- ajoute les styles et attributs d’accessibilité du nouveau badge et met à jour l’UI responsive
- simplifie la logique JS du tri et synchronise l’état du badge des vues intelligentes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d449355b3c8331b6dbecc0e75b67a7