### PR TITLE
Add animated card entry, status pulses, and header breathing gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,10 @@
         inset: 0;
         border-radius: inherit;
         background: var(--header-overlay);
+        background-size: 180% 180%;
+        animation: headerBreath 30s ease-in-out infinite;
+        opacity: 0.85;
+        filter: none;
         z-index: -1;
       }
       .topbar {
@@ -378,6 +382,24 @@
       overflow: hidden;
       isolation: isolate;
     }
+    header.page-header::before {
+      content: "";
+      position: absolute;
+      inset: -18% -22% -24%;
+      border-radius: inherit;
+      background: linear-gradient(
+          135deg,
+          rgba(115, 135, 215, 0.25) 0%,
+          rgba(90, 183, 164, 0.22) 50%,
+          rgba(115, 135, 215, 0.28) 100%
+        );
+      background-size: 220% 220%;
+      opacity: 0.52;
+      filter: blur(18px);
+      animation: headerBreath 26s ease-in-out infinite;
+      pointer-events: none;
+      z-index: 0;
+    }
     header.page-header::after {
       content: "";
       position: absolute;
@@ -393,11 +415,28 @@
       pointer-events: none;
       mix-blend-mode: screen;
       animation: headerGlow 14s ease-in-out infinite alternate;
-      z-index: 0;
+      z-index: 1;
     }
     header.page-header > * {
       position: relative;
-      z-index: 1;
+      z-index: 2;
+    }
+    @keyframes headerBreath {
+      0% {
+        opacity: 0.42;
+        background-position: 0% 40%;
+        transform: scale(0.98);
+      }
+      50% {
+        opacity: 0.72;
+        background-position: 55% 100%;
+        transform: scale(1.02);
+      }
+      100% {
+        opacity: 0.45;
+        background-position: 100% 40%;
+        transform: scale(0.99);
+      }
     }
     @keyframes headerGlow {
       0% {
@@ -1093,22 +1132,106 @@
       gap: clamp(12px, 2vw, 18px);
     }
     .card {
+      position: relative;
       background: var(--card-bg);
       border-radius: var(--radius-lg);
       border: 1px solid var(--card-border);
       padding: 18px 18px 16px;
       box-shadow: var(--shadow-md);
-      animation: fade 0.25s ease;
       backdrop-filter: blur(2px);
+      animation: cardFade 0.3s ease both;
+      overflow: hidden;
+      --card-flash: rgba(115, 135, 215, 0.32);
     }
-    @keyframes fade {
+    .card[data-status="pause"] {
+      --card-flash: rgba(242, 179, 106, 0.32);
+    }
+    .card[data-status="done"] {
+      --card-flash: rgba(90, 183, 164, 0.32);
+    }
+    .card::before {
+      content: "";
+      position: absolute;
+      inset: -8px;
+      border-radius: inherit;
+      background: radial-gradient(120% 140% at 50% 45%, var(--card-flash), transparent 72%);
+      opacity: 0;
+      pointer-events: none;
+      mix-blend-mode: screen;
+      transition: opacity 0.3s ease;
+    }
+    .card::after {
+      content: "";
+      position: absolute;
+      inset: -16px;
+      border-radius: inherit;
+      background: radial-gradient(120% 140% at 50% 40%, rgba(115, 135, 215, 0.35), transparent 70%);
+      opacity: 0;
+      pointer-events: none;
+      mix-blend-mode: screen;
+    }
+    .card.card--enter {
+      animation: cardSlideGlow 0.65s cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    .card.card--enter::after {
+      animation: cardHalo 0.65s ease-out forwards;
+    }
+    .card--status-flash::before {
+      animation: cardStatusFlash 0.6s ease-out forwards;
+    }
+    @keyframes cardFade {
       from {
         opacity: 0;
-        transform: translateY(12px);
+        transform: translateY(10px);
       }
       to {
         opacity: 1;
         transform: none;
+      }
+    }
+    @keyframes cardSlideGlow {
+      0% {
+        opacity: 0;
+        transform: translateY(24px);
+        box-shadow: 0 18px 42px rgba(90, 183, 164, 0.2);
+      }
+      55% {
+        opacity: 1;
+        transform: translateY(-4px);
+        box-shadow: 0 22px 48px rgba(90, 183, 164, 0.28);
+      }
+      100% {
+        opacity: 1;
+        transform: none;
+        box-shadow: var(--shadow-md);
+      }
+    }
+    @keyframes cardHalo {
+      0% {
+        opacity: 0.75;
+        transform: scale(0.92);
+      }
+      60% {
+        opacity: 0.35;
+        transform: scale(1.04);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(1.08);
+      }
+    }
+    @keyframes cardStatusFlash {
+      0% {
+        opacity: 0.5;
+        transform: scale(0.96);
+      }
+      60% {
+        opacity: 0.2;
+        transform: scale(1.02);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(1.05);
       }
     }
     .row {
@@ -1136,6 +1259,7 @@
       text-overflow: ellipsis;
     }
     .badge {
+      --badge-halo: rgba(115, 135, 215, 0.35);
       padding: 6px 12px;
       border-radius: 999px;
       font-size: 0.75rem;
@@ -1145,16 +1269,35 @@
       background: var(--badge-bg);
       border: 1px solid var(--badge-border);
       color: var(--badge-text);
+      box-shadow: none;
+      transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease,
+        box-shadow 0.4s ease;
     }
     .badge[data-s="pause"] {
+      --badge-halo: rgba(242, 179, 106, 0.45);
       background: var(--badge-pause-bg);
       border-color: var(--badge-pause-border);
       color: var(--badge-pause-text);
     }
     .badge[data-s="done"] {
+      --badge-halo: rgba(90, 183, 164, 0.45);
       background: var(--badge-done-bg);
       border-color: var(--badge-done-border);
       color: var(--badge-done-text);
+    }
+    .badge--pulse {
+      animation: badgePulse 0.7s ease-out;
+    }
+    @keyframes badgePulse {
+      0% {
+        box-shadow: 0 0 0 0 var(--badge-halo);
+      }
+      65% {
+        box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
+      }
+      100% {
+        box-shadow: 0 0 0 14px rgba(0, 0, 0, 0);
+      }
     }
     .meta {
       margin-top: 10px;
@@ -2577,6 +2720,9 @@
       } else {
         item.activeMs = active;
       }
+      if (!Number.isFinite(Number(item.statusChangedAt))) {
+        item.statusChangedAt = 0;
+      }
       if (typeof item.durationSec !== "number" || Number.isNaN(item.durationSec) || item.durationSec < 0) {
         item.durationSec = item.status === "done" ? Math.floor(item.activeMs / 1000) : 0;
       }
@@ -2625,6 +2771,7 @@
         }
         return;
       }
+      item.statusChangedAt = ts;
       if (nextStatus === "wait") {
         if (current === "wait") return;
         if (current === "done") {
@@ -2684,6 +2831,7 @@
         durationSec: baseDuration > 0 ? baseDuration : 0,
         activeMs: Number.isFinite(activeMs) && activeMs >= 0 ? activeMs : Math.max(0, baseDuration) * 1000,
         lastResumeTime: null,
+        statusChangedAt: createdAt,
       };
       if (item.status === "wait") {
         item.lastResumeTime = o.lastResumeTime || start;
@@ -3344,17 +3492,23 @@
           const isWait = i.status === "wait";
           const liveSec = getEffectiveSeconds(i, nowTs);
           const longAwait = isWait && nowTs - (i.startTime || nowTs) > 3600 * 1000;
-          const cls = longAwait ? "card awaiting-long" : "card";
+          const justChanged =
+            Number.isFinite(i.statusChangedAt) && i.statusChangedAt > 0 && nowTs - i.statusChangedAt < 1400;
+          const classes = ["card"];
+          if (longAwait) classes.push("awaiting-long");
+          if (justChanged) classes.push("card--status-flash");
+          const cardClassName = classes.join(" ");
+          const badgeClasses = justChanged ? "badge badge--pulse" : "badge";
           const pauseLabel = i.status === "pause" ? "Reprendre" : "Pause";
           const pauseIcon = i.status === "pause" ? ICONS.play : ICONS.pause;
           const doneLabel = i.status === "done" ? "Reprendre" : "Terminer";
           const doneIcon = i.status === "done" ? ICONS.refresh : ICONS.check;
           return `
-          <div class="${cls}" data-id="${i.id}">
+          <div class="${cardClassName}" data-id="${i.id}" data-status="${i.status}">
             <div class="row">
               <div class="handle" title="Déplacer">≡</div>
               <div class="title"><span>${escapeHtml(i.name)}</span></div>
-              <span class="badge" data-s="${i.status}">${statusLabel(i.status)}</span>
+              <span class="${badgeClasses}" data-s="${i.status}">${statusLabel(i.status)}</span>
             </div>
             <div class="meta">
               <span>Client : <b>${escapeHtml(i.client)}</b></span>
@@ -3397,7 +3551,8 @@
 
       // anim carte à l'ajout
       if (cardInAnimationNextRender && list.firstElementChild) {
-        list.firstElementChild.style.animation = "fade .25s ease";
+        const firstCard = list.firstElementChild;
+        firstCard.classList.add("card--enter");
         cardInAnimationNextRender = false;
       }
 


### PR DESCRIPTION
## Summary
- add a slide-and-glow animation for incoming cards and a subtle status flash driven by stored timestamps
- animate the status badges with a quick halo pulse when their status changes
- give the header a slow breathing gradient overlay for constant motion across viewports

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d44c9e12708331934b6c73436410ed