### PR TITLE
Add batch CSV import parsing and deadline display

### DIFF
--- a/index.html
+++ b/index.html
@@ -2012,6 +2012,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+  <script type="module" src="./parse-batch-csv.js"></script>
   <script>
     /* ====== State & Utils ====== */
     const K = "vmach_badges_v1";
@@ -2697,6 +2698,43 @@
         d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })
       );
     }
+    function fmtShortDate(ts) {
+      if (!ts) return "—";
+      const d = new Date(ts);
+      if (Number.isNaN(d.getTime())) return "—";
+      return d.toLocaleDateString("fr-FR");
+    }
+    function parseDeadlineValue(value) {
+      if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value.getTime();
+      }
+      const num = Number(value);
+      if (Number.isFinite(num) && num > 0) {
+        return num;
+      }
+      if (typeof value !== "string") return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const iso = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (iso) {
+        const [, year, month, day] = iso;
+        return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+      }
+      const full = trimmed.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+      if (full) {
+        const [, day, month, year] = full;
+        return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+      }
+      const short = trimmed.match(/^(\d{2})\/(\d{2})$/);
+      if (short) {
+        const [, day, month] = short;
+        const currentYear = new Date().getFullYear();
+        return new Date(currentYear, Number(month) - 1, Number(day)).getTime();
+      }
+      const parsed = Date.parse(trimmed);
+      if (!Number.isNaN(parsed)) return parsed;
+      return null;
+    }
     function fmtDur(s) {
       if (!s || s < 1) return "—";
       const h = Math.floor(s / 3600),
@@ -2737,6 +2775,10 @@
       if (!item || typeof item !== "object") return item;
       if (!item.startTime) {
         item.startTime = now();
+      }
+      if ("deadline" in item) {
+        const parsedDeadline = parseDeadlineValue(item.deadline);
+        item.deadline = parsedDeadline;
       }
       ensureTimerFields(item);
       if (item.status === "done") {
@@ -2824,6 +2866,7 @@
         finish: o.finish,
         type: o.type,
         carton: o.carton,
+        deadline: parseDeadlineValue(o.deadline),
         status,
         note: (o.note || "").trim(),
         startTime: start,
@@ -3479,7 +3522,11 @@
           " " +
           i.type +
           " " +
-          i.carton
+          (i.carton || "") +
+          " " +
+          (i.note || "") +
+          " " +
+          (i.deadline ? fmtShortDate(i.deadline) : "")
         ).toLowerCase();
         return s.includes(search);
       });
@@ -3515,6 +3562,11 @@
               <span>Qté : <b>${i.qty}</b></span>
               <span>${i.diam}</span><span>${i.finish}</span><span>${i.type}</span><span>${i.carton}</span>
             </div>
+            ${
+              i.deadline
+                ? `<div class="meta"><span>Échéance : <b>${fmtShortDate(i.deadline)}</b></span></div>`
+                : ""
+            }
             <div class="meta">
               <span>Créé : ${fmtDate(i.startTime)}</span>
               ${
@@ -3837,6 +3889,9 @@
       boite: "carton",
       boîte: "carton",
       box: "carton",
+      deadline: "deadline",
+      echeance: "deadline",
+      due: "deadline",
       status: "status",
       statut: "status",
       starttime: "startTime",
@@ -4035,6 +4090,7 @@
       const startTime = parseOptionalTimestamp(record.startTime, lineNumber, "début");
       const endTime = parseOptionalTimestamp(record.endTime, lineNumber, "fin");
       const lastResumeTime = parseOptionalTimestamp(record.lastResumeTime, lineNumber, "reprise");
+      const deadline = parseDeadlineValue(record.deadline);
       const item = {
         id: generateItemId(),
         client,
@@ -4044,6 +4100,7 @@
         finish,
         type,
         carton,
+        deadline,
         status: "wait",
         note: (record.note || "").trim(),
         startTime: startTime ?? now(),
@@ -4095,17 +4152,64 @@
       return result;
     }
 
+    function getBatchImportDefaults() {
+      return {
+        client: "",
+        name: "",
+        qty: 1,
+        diam: lastFormValues?.diam || "58 mm",
+        finish: lastFormValues?.finish || "Mat",
+        type: lastFormValues?.type || "Aimant décoratif",
+        carton: lastFormValues?.carton || "Boîte A11",
+        deadline: null,
+        note: "",
+      };
+    }
+
     async function handleCsvImportChange(event) {
       const input = event.target;
       const file = input?.files?.[0];
       if (!file) return;
       try {
         const content = await file.text();
-        const records = parseCsvContent(content);
-        if (!records.length) {
-          throw new Error("Aucune donnée trouvée dans le fichier.");
+        let importedItems = null;
+        let lastError = null;
+        try {
+          const records = parseCsvContent(content);
+          if (!records.length) {
+            throw new Error("Aucune donnée trouvée dans le fichier.");
+          }
+          importedItems = records.map((entry) => recordToItem(entry.data, entry.lineNumber));
+        } catch (err) {
+          lastError = err;
+          importedItems = null;
         }
-        const importedItems = records.map((entry) => recordToItem(entry.data, entry.lineNumber));
+        if ((!importedItems || !importedItems.length) && typeof window !== "undefined") {
+          const batchParser = window.parseBatchCsv;
+          if (typeof batchParser === "function") {
+            try {
+              const batchRecords = batchParser(content, getBatchImportDefaults()) || [];
+              if (batchRecords.length) {
+                importedItems = batchRecords.map((entry) => {
+                  const created = newItem(entry);
+                  transitionStatus(created, created.status, created.startTime || now());
+                  return created;
+                });
+                lastError = null;
+                console.info(
+                  `Import CSV batch interprété (${importedItems.length} commande${
+                    importedItems.length > 1 ? "s" : ""
+                  }).`
+                );
+              }
+            } catch (batchErr) {
+              lastError = batchErr;
+            }
+          }
+        }
+        if (!importedItems || !importedItems.length) {
+          throw lastError || new Error("Aucune donnée trouvée dans le fichier.");
+        }
         const replaceAll =
           !items.length ||
           confirm(
@@ -4151,6 +4255,7 @@
         finish: c.finish,
         type: c.type,
         carton: c.carton,
+        deadline: c.deadline ? fmtShortDate(c.deadline) : "",
         status: c.status,
         startTime: c.startTime,
         endTime: c.endTime || "",
@@ -4191,13 +4296,13 @@
           <td>${escapeHtml(i.client)}</td>
           <td style="text-align:right">${i.qty}</td>
           <td>${i.diam}</td><td>${i.finish}</td><td>${i.type}</td><td>${i.carton}</td><td>${escapeHtml(i.note || "")}</td>
-          <td>${fmtDate(i.startTime)}</td><td>${fmtDate(i.endTime)}</td>
+          <td>${fmtShortDate(i.deadline)}</td><td>${fmtDate(i.startTime)}</td><td>${fmtDate(i.endTime)}</td>
           ${durCell}
         </tr>`;
         })
         .join("");
 
-      const headCols = `<th>Nom</th><th>Client</th><th>Qté</th><th>Format</th><th>Finition</th><th>Attache</th><th>Carton</th><th>Note</th><th>Créé</th><th>Terminé</th>${
+      const headCols = `<th>Nom</th><th>Client</th><th>Qté</th><th>Format</th><th>Finition</th><th>Attache</th><th>Carton</th><th>Note</th><th>Échéance</th><th>Créé</th><th>Terminé</th>${
         withDur ? "<th>Durée</th>" : ""
       }`;
       const htmlTable = `
@@ -4216,9 +4321,11 @@
           const endLabel = fmtDate(i.endTime);
           const endPart = endLabel !== "—" ? ` • Terminé: ${endLabel}` : "";
           const note = (i.note || "").trim();
+          const deadlineShort = fmtShortDate(i.deadline);
           const lines = [
             `${idx + 1}. ${i.name} — ${i.client}`,
-            `   Qté: ${i.qty} • Format: ${i.diam} • Finition: ${i.finish} • Attache: ${i.type} • Carton: ${i.carton}`,
+            `   Qté: ${i.qty} • Format: ${i.diam} • Finition: ${i.finish} • Attache: ${i.type} • Carton: ${i.carton}` +
+              (deadlineShort !== "—" ? ` • Échéance: ${deadlineShort}` : ""),
             `   Créé: ${fmtDate(i.startTime)}${endPart}${durLabel}`,
           ];
           if (note) {

--- a/parse-batch-csv.js
+++ b/parse-batch-csv.js
@@ -1,0 +1,295 @@
+const stripAccents = (value) => {
+  if (value == null) return "";
+  const str = String(value);
+  const normalized =
+    typeof str.normalize === "function"
+      ? str
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .replace(/\u00a0/g, " ")
+      : str;
+  return normalized.replace(/[×✕✖]/g, "x");
+};
+
+const normalizeToken = (token) =>
+  stripAccents(token)
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/[^a-z0-9x]/g, "");
+
+const detectDelimiter = (line) => {
+  if (!line) return ";";
+  const semi = (line.match(/;/g) || []).length;
+  const comma = (line.match(/,/g) || []).length;
+  if (semi === 0 && comma === 0) return ";";
+  return semi >= comma ? ";" : ",";
+};
+
+const splitCsvLine = (line, delimiter) => {
+  const result = [];
+  let current = "";
+  let inQuotes = false;
+  for (let idx = 0; idx < line.length; idx++) {
+    const char = line[idx];
+    if (idx === 0 && char === "\ufeff") continue;
+    if (inQuotes) {
+      if (char === "\"") {
+        if (line[idx + 1] === "\"") {
+          current += "\"";
+          idx++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else if (char === "\"") {
+      inQuotes = true;
+    } else if (char === delimiter) {
+      result.push(current);
+      current = "";
+    } else if (char === "\r") {
+      continue;
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+};
+
+const looksLikeHeader = (cells) => {
+  if (!Array.isArray(cells) || !cells.length) return false;
+  const sample = cells.map((cell) => normalizeToken(cell || ""));
+  const headerHints = new Set([
+    "client",
+    "clients",
+    "nom",
+    "name",
+    "designation",
+    "qty",
+    "quantite",
+    "qte",
+    "qt",
+  ]);
+  return (
+    headerHints.has(sample[6]) ||
+    headerHints.has(sample[7]) ||
+    headerHints.has(sample[11])
+  );
+};
+
+const parseQuantity = (value) => {
+  if (value == null) return null;
+  const normalized = String(value).replace(/[^0-9]/g, "");
+  if (!normalized) return null;
+  const num = Number.parseInt(normalized, 10);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return num;
+};
+
+const parseDeadline = (value) => {
+  if (value == null) return null;
+  const str = stripAccents(String(value)).trim();
+  if (!str) return null;
+  const full = str.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (full) {
+    const [, day, month, year] = full;
+    return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+  }
+  const iso = str.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (iso) {
+    const [, year, month, day] = iso;
+    return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+  }
+  const short = str.match(/^(\d{2})\/(\d{2})$/);
+  if (short) {
+    const [, day, month] = short;
+    const year = new Date().getFullYear();
+    return new Date(year, Number(month) - 1, Number(day)).getTime();
+  }
+  return null;
+};
+
+const FORMAT_TOKEN_MAP = {
+  diam: {
+    "28": "28 mm",
+    "28mm": "28 mm",
+    "38": "38 mm",
+    "38mm": "38 mm",
+    "45": "45 mm",
+    "45mm": "45 mm",
+    "58": "58 mm",
+    "58mm": "58 mm",
+    "89": "89 mm",
+    "89mm": "89 mm",
+    "rect": "Rect. 80 × 50 mm",
+    "rectangle": "Rect. 80 × 50 mm",
+    "rectangulaire": "Rect. 80 × 50 mm",
+    "80x50": "Rect. 80 × 50 mm",
+    "80*50": "Rect. 80 × 50 mm",
+    "8050": "Rect. 80 × 50 mm",
+    "80×50": "Rect. 80 × 50 mm",
+  },
+  type: {
+    mag: "Aimant décoratif",
+    aimant: "Aimant décoratif",
+    magnet: "Aimant décoratif",
+    aimantdecoratif: "Aimant décoratif",
+    decoratif: "Aimant décoratif",
+    neo: "Magnétique textile",
+    neodyme: "Magnétique textile",
+    magnetique: "Magnétique textile",
+    textile: "Magnétique textile",
+    epi: "Épingle",
+    epingle: "Épingle",
+    pin: "Épingle",
+    decap: "Décapsuleur magnet",
+    decapsuleur: "Décapsuleur magnet",
+  },
+  finish: {
+    st: "Mat",
+    satine: "Mat",
+    satinee: "Mat",
+    satiné: "Mat",
+    mat: "Mat",
+    matte: "Mat",
+    br: "Brillant",
+    brillant: "Brillant",
+    brillante: "Brillant",
+    gloss: "Brillant",
+  },
+};
+
+const parseFormatCell = (cell, defaults) => {
+  const normalized = stripAccents(cell || "")
+    .toLowerCase()
+    .replace(/(\d+)\/(\d+)/g, "$1x$2");
+  const rawTokens = normalized
+    .split(/[^a-z0-9x]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const seen = new Set();
+  const unknownTokens = [];
+  let diam = null;
+  let type = null;
+  let finish = null;
+  rawTokens.forEach((tokenRaw) => {
+    if (!tokenRaw) return;
+    const token = normalizeToken(tokenRaw);
+    if (!token || seen.has(token)) return;
+    seen.add(token);
+    if (!diam) {
+      const mappedDiam = FORMAT_TOKEN_MAP.diam[token];
+      if (mappedDiam) {
+        diam = mappedDiam;
+        return;
+      }
+      if (token.endsWith("mm")) {
+        const base = token.replace(/mm$/, "");
+        if (FORMAT_TOKEN_MAP.diam[base]) {
+          diam = FORMAT_TOKEN_MAP.diam[base];
+          return;
+        }
+      }
+    }
+    if (!type) {
+      const mappedType = FORMAT_TOKEN_MAP.type[token];
+      if (mappedType) {
+        type = mappedType;
+        return;
+      }
+    }
+    if (!finish) {
+      const mappedFinish = FORMAT_TOKEN_MAP.finish[token];
+      if (mappedFinish) {
+        finish = mappedFinish;
+        return;
+      }
+    }
+    unknownTokens.push(tokenRaw);
+  });
+  return {
+    diam: diam || defaults.diam || "",
+    type: type || defaults.type || "",
+    finish: finish || defaults.finish || "",
+    unknownTokens,
+  };
+};
+
+const cleanValue = (value) => {
+  if (value == null) return "";
+  return String(value).trim();
+};
+
+export function parseBatchCsv(input, defaults = {}) {
+  if (typeof input !== "string") {
+    throw new Error("Le contenu CSV doit être une chaîne de caractères.");
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const lines = trimmed.split(/\r?\n/).filter((line) => line.trim().length);
+  if (!lines.length) return [];
+  const delimiter = detectDelimiter(lines[0]);
+  const now = Date.now();
+  const defaultsDeadline = parseDeadline(defaults.deadline);
+  const results = [];
+  let headerSkipped = false;
+  lines.forEach((line, index) => {
+    const cells = splitCsvLine(line, delimiter);
+    if (!cells.length) return;
+    if (!headerSkipped && looksLikeHeader(cells)) {
+      headerSkipped = true;
+      return;
+    }
+    const qty = parseQuantity(cells[11]);
+    const client = cleanValue(cells[6]) || cleanValue(defaults.client);
+    const name = cleanValue(cells[7]) || cleanValue(defaults.name);
+    if (!qty || !client || !name) {
+      return;
+    }
+    const formatInfo = parseFormatCell(cells[3], defaults);
+    const baseNote = cleanValue(cells[8]);
+    const noteParts = [];
+    if (defaults.note) noteParts.push(String(defaults.note));
+    if (baseNote) noteParts.push(baseNote);
+    if (formatInfo.unknownTokens.length) {
+      noteParts.push(`Tokens inconnus: ${formatInfo.unknownTokens.join(", ")}`);
+    }
+    const deadline = parseDeadline(cells[2]);
+    results.push({
+      client,
+      name,
+      qty,
+      diam: formatInfo.diam,
+      finish: formatInfo.finish,
+      type: formatInfo.type,
+      carton: cleanValue(defaults.carton),
+      deadline: Number.isFinite(deadline)
+        ? deadline
+        : Number.isFinite(defaultsDeadline)
+        ? defaultsDeadline
+        : null,
+      note: noteParts.join("\n").trim(),
+      status: "wait",
+      startTime: now,
+      endTime: null,
+      durationSec: 0,
+    });
+  });
+  const preview = results.slice(0, 5);
+  if (preview.length) {
+    console.log("Aperçu import badges (5 premiers):", preview);
+  } else {
+    console.log("Aucun enregistrement interprété depuis le CSV batch.");
+  }
+  return results;
+}
+
+if (typeof window !== "undefined") {
+  window.parseBatchCsv = parseBatchCsv;
+}
+
+export default parseBatchCsv;


### PR DESCRIPTION
## Summary
- add a reusable `parseBatchCsv` module that reads supplier CSVs, normalizes format tokens, and logs a preview of the first rows
- surface deadline data across the UI and exports while normalizing stored items for legacy data
- fall back to the batch parser during import using defaults seeded from the last form values when the legacy parser fails

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4521bbc008331b1cb12ca3fbe094c