### PR TITLE
Compact header with unified menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       --radius-sm: 12px;
       --touch: 52px;
       --safe-bottom: env(safe-area-inset-bottom, 18px);
-      --header-h: 208px;
+      --header-h: 176px;
       --page-pad: clamp(18px, 4vw, 48px);
       font-size: 16px;
     }
@@ -299,8 +299,8 @@
         z-index: -1;
       }
       .topbar {
-        padding: calc(env(safe-area-inset-top, 0) + clamp(18px, 6vw, 28px)) var(--page-pad)
-          clamp(16px, 5vw, 24px);
+        padding: calc(env(safe-area-inset-top, 0) + clamp(14px, 5vw, 22px)) var(--page-pad)
+          clamp(12px, 4vw, 20px);
       }
       .chip-row {
         margin: 0;
@@ -465,12 +465,13 @@
     }
     .topbar {
       margin: 0;
-      padding: clamp(18px, 3vw, 28px) clamp(18px, 3vw, 28px) clamp(14px, 2.5vw, 22px);
+      padding: clamp(16px, 2.5vw, 24px) clamp(16px, 2.5vw, 24px) clamp(12px, 2vw, 18px);
       display: grid;
-      gap: clamp(12px, 2vw, 18px);
+      gap: clamp(10px, 1.6vw, 16px);
       position: relative;
       overflow: hidden;
       border-radius: inherit;
+      align-content: start;
     }
     .topbar::after {
       content: "";
@@ -505,36 +506,26 @@
       flex: 1;
     }
     .brand img {
-      width: 36px;
-      height: 36px;
+      width: 32px;
+      height: 32px;
       border-radius: 12px;
       box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
     }
     .brand__text {
       display: flex;
       flex-direction: column;
-      gap: 2px;
-      line-height: 1.1;
+      gap: 0;
+      line-height: 1.05;
     }
     .brand__text strong {
-      font-size: 1.05rem;
+      font-size: 1.1rem;
       letter-spacing: 0.2px;
     }
-    .brand__text span {
-      font-size: 0.75rem;
-      color: var(--text-subtle);
-      letter-spacing: 0.4px;
-      text-transform: uppercase;
-    }
-    .brand__text small {
+    .brand__subtitle {
       font-size: 0.7rem;
-      color: var(--text-soft);
-      letter-spacing: 0.36px;
+      color: var(--text-subtle);
+      letter-spacing: 0.32px;
       text-transform: uppercase;
-    }
-    .topbar__actions {
-      display: flex;
-      gap: 8px;
     }
     button {
       font-family: inherit;
@@ -555,9 +546,41 @@
       white-space: nowrap;
       border: 0;
     }
+    .topbar__menu-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 16px;
+      height: 40px;
+      border-radius: 999px;
+      color: var(--text);
+      background: var(--header-icon-bg);
+      border: 1px solid var(--header-icon-border);
+      box-shadow: var(--header-icon-shadow);
+      font-weight: 600;
+      font-size: 0.85rem;
+      letter-spacing: 0.2px;
+      transition: transform 0.18s ease;
+    }
+    .topbar__menu-btn .ico {
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+    .topbar__menu-btn .label {
+      text-transform: uppercase;
+      letter-spacing: 0.36px;
+    }
+    .topbar__menu-btn:active {
+      transform: translateY(1px) scale(0.98);
+    }
+    .topbar__menu-btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+      border-radius: 999px;
+    }
     .icon-btn {
-      width: 42px;
-      height: 42px;
+      width: 36px;
+      height: 36px;
       border-radius: 50%;
       display: grid;
       place-items: center;
@@ -621,21 +644,22 @@
     }
     .utility {
       display: flex;
-      gap: 10px;
+      flex-wrap: wrap;
+      gap: 12px;
       align-items: center;
     }
     .search {
       position: relative;
-      flex: 1;
+      flex: 1 1 220px;
     }
     .search input {
       width: 100%;
-      padding: 12px 44px 12px 16px;
+      padding: 10px 42px 10px 14px;
       border-radius: 999px;
       border: 1px solid var(--field-border);
       background: var(--field-bg);
       color: var(--text);
-      font-size: 0.95rem;
+      font-size: 0.9rem;
       box-shadow: var(--field-shadow);
     }
     .search input::placeholder {
@@ -654,12 +678,12 @@
       align-items: center;
       gap: 8px;
       flex-wrap: wrap;
-      padding: 10px 14px;
+      padding: 8px 12px;
       border-radius: 999px;
       background: var(--ghost-bg);
       border: 1px solid var(--ghost-border);
       color: var(--ghost-text);
-      font-size: 0.85rem;
+      font-size: 0.8rem;
       font-weight: 600;
     }
     .smart-badge strong {
@@ -687,6 +711,30 @@
     }
     .smart-badge[hidden] {
       display: none;
+    }
+
+    @media (min-width: 960px) {
+      .topbar {
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+        grid-template-areas:
+          "head head"
+          "chips utility";
+        align-items: center;
+      }
+      .topbar__head {
+        grid-area: head;
+      }
+      .chip-row {
+        grid-area: chips;
+        margin-bottom: 0;
+      }
+      .utility {
+        grid-area: utility;
+        justify-content: flex-end;
+      }
+      .utility .search {
+        flex: 0 0 clamp(240px, 26vw, 340px);
+      }
     }
 
     .menu-overlay {
@@ -1568,9 +1616,6 @@
       .insights__actions {
         justify-content: flex-start;
       }
-      #insightToggle {
-        display: none;
-      }
       #closeInsights {
         display: none;
       }
@@ -1613,35 +1658,22 @@
             alt="V‑MACH"
           />
           <div class="brand__text">
-            <strong>Production badges</strong>
-            <span>V‑MACH</span>
-            <small>Suivi temps réel des commandes</small>
+            <strong>Dashboard Badges</strong>
+            <span class="brand__subtitle">V‑MACH</span>
           </div>
         </div>
-        <div class="topbar__actions">
-          <button
-            id="menuBtn"
-            class="icon-btn"
-            type="button"
-            aria-expanded="false"
-            aria-controls="commandMenu"
-            aria-label="Menu principal"
-            title="Menu principal"
-          >
-            ☰
-          </button>
-          <button
-            id="insightToggle"
-            class="icon-btn"
-            type="button"
-            aria-expanded="false"
-            aria-controls="insights"
-            title="Afficher les compteurs"
-          >
-            📊
-          </button>
-          <button id="settingsBtn" class="icon-btn" type="button" title="Réglages">⚙️</button>
-        </div>
+        <button
+          id="menuBtn"
+          class="topbar__menu-btn"
+          type="button"
+          aria-expanded="false"
+          aria-controls="commandMenu"
+          aria-label="Ouvrir le menu principal"
+          title="Ouvrir le menu principal"
+        >
+          <span class="ico" aria-hidden="true">☰</span>
+          <span class="label">Menu</span>
+        </button>
       </div>
       <div class="chip-row" id="filters">
         <button class="chip active" data-f="all">Toutes</button>
@@ -2972,16 +3004,35 @@
       setDenseMode($("#optDense").checked);
     };
 
-    $("#settingsBtn").onclick = () => {
-      $("#settings").classList.add("open");
+    const settingsPanel = $("#settings");
+    const closeSettingsBtn = $("#closeSettings");
+
+    function openSettingsPanel() {
+      if (!settingsPanel) return;
+      settingsPanel.classList.add("open");
+      settingsPanel.setAttribute("aria-hidden", "false");
       vibrate();
       syncHeaderOffset();
-    };
-    $("#closeSettings").onclick = () => {
-      $("#settings").classList.remove("open");
+    }
+
+    function closeSettingsPanel() {
+      if (!settingsPanel) return;
+      settingsPanel.classList.remove("open");
+      settingsPanel.setAttribute("aria-hidden", "true");
       vibrate();
       syncHeaderOffset();
-    };
+    }
+
+    if (closeSettingsBtn) {
+      closeSettingsBtn.onclick = () => {
+        closeSettingsPanel();
+      };
+    }
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && settingsPanel?.classList.contains("open")) {
+        closeSettingsPanel();
+      }
+    });
     $("#clearAll").onclick = () => {
       if (confirm("Supprimer toutes les commandes ?")) {
         items = [];
@@ -3053,7 +3104,7 @@
           setInsightsOpen(true);
           break;
         case "open-settings":
-          $("#settingsBtn")?.click();
+          openSettingsPanel();
           break;
         case "export-email":
           $("#exportEmail")?.click();


### PR DESCRIPTION
## Summary
- remanié l'entête pour mettre en avant "Dashboard Badges" avec un bouton de menu unique
- resserré la mise en page du topbar, des filtres et de la recherche pour un en-tête plus compact
- centralisé l'ouverture des réglages dans le menu et ajouté la fermeture au clavier

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d455d779688331b402ae95919fb90d