### PR TITLE
Fix mobile header layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,9 @@
         align-items: stretch;
         gap: 12px;
       }
+      .utility .search {
+        flex: none;
+      }
       .search input {
         min-height: 46px;
         font-size: 1rem;


### PR DESCRIPTION
## Summary
- fix the mobile utility bar layout so the search field no longer reserves legacy header height

## Testing
- Manual testing on mobile viewport in browser

------
https://chatgpt.com/codex/tasks/task_e_68d45a13f43c833190f55b360c07a50e