### PR TITLE
Adjust urgent smart view and add deadline sort

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,6 +1541,7 @@
         <div class="command-menu__toggles">
           <button class="command-menu__toggle" type="button" data-sort="recent">Plus récents</button>
           <button class="command-menu__toggle" type="button" data-sort="oldest">Plus anciens</button>
+          <button class="command-menu__toggle" type="button" data-sort="deadline">Par échéance</button>
           <button class="command-menu__toggle" type="button" data-sort="qty">Gros volumes</button>
           <button class="command-menu__toggle" type="button" data-sort="status">Par statut</button>
         </div>
@@ -1765,7 +1766,7 @@
         id: "urgent",
         label: "Urgences",
         description:
-          "Met en avant les commandes en attente depuis plus de 90 minutes ou proches de leur échéance.",
+          "Affiche les commandes dont l'échéance est atteinte ou prévue dans les 48 heures.",
       },
       highVolume: {
         id: "highVolume",
@@ -1778,10 +1779,9 @@
         description: "Affiche les commandes clôturées sur les dernières 24 heures.",
       },
     };
-    const URGENT_DELAY_MS = 90 * 60 * 1000;
     const RECENT_DONE_MS = 24 * 60 * 60 * 1000;
     const HIGH_VOLUME_QTY = 200;
-    const DEADLINE_SOON_MS = 24 * 60 * 60 * 1000;
+    const DEADLINE_SOON_MS = 48 * 60 * 60 * 1000;
     const ICONS = {
       edit: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>',
       pause: '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16" rx="1"></rect><rect x="14" y="4" width="4" height="16" rx="1"></rect></svg>',
@@ -2977,7 +2977,13 @@
       const copy = [...list];
       if (sortBy === "recent") copy.sort((a, b) => (b.startTime || 0) - (a.startTime || 0));
       else if (sortBy === "oldest") copy.sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
-      else if (sortBy === "qty") copy.sort((a, b) => (b.qty || 0) - (a.qty || 0));
+      else if (sortBy === "deadline") {
+        const getDeadline = (item) => {
+          const deadline = Number(item?.deadline);
+          return Number.isFinite(deadline) && deadline > 0 ? deadline : Infinity;
+        };
+        copy.sort((a, b) => getDeadline(a) - getDeadline(b));
+      } else if (sortBy === "qty") copy.sort((a, b) => (b.qty || 0) - (a.qty || 0));
       else if (sortBy === "client")
         copy.sort((a, b) => a.client.localeCompare(b.client, "fr", { sensitivity: "base" }));
       else if (sortBy === "status") {
@@ -2998,13 +3004,7 @@
     function applySmartFilter(list, ts) {
       if (!Array.isArray(list)) return [];
       if (smartFilter === "urgent") {
-        return list.filter((item) => {
-          if (!item || item.status === "done") return false;
-          if (isDeadlineUrgent(item, ts)) return true;
-          const startRef = item.lastResumeTime || item.startTime || 0;
-          if (!startRef) return false;
-          return ts - startRef >= URGENT_DELAY_MS;
-        });
+        return list.filter((item) => isDeadlineUrgent(item, ts));
       }
       if (smartFilter === "highVolume") {
         return list.filter((item) => Number(item?.qty) >= HIGH_VOLUME_QTY);


### PR DESCRIPTION
## Summary
- limit the Urgences vue intelligente to commands with deadlines due within 48 hours
- update the smart filter description to reflect the new behaviour
- add a "Par échéance" sorting option and order items by their deadline when selected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4616497b0833181244da6eb12dd1e